### PR TITLE
Add browser name for HtmlUnit

### DIFF
--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/HtmlUnitDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/HtmlUnitDriverConfig.java
@@ -13,6 +13,7 @@ public class HtmlUnitDriverConfig extends WebDriverConfig<HtmlUnitDriver> {
         DesiredCapabilities capabilities = new DesiredCapabilities();
         capabilities.setCapability(CapabilityType.PROXY, createProxy());
         capabilities.setCapability("javascriptEnabled", "true");
+        capabilities.setBrowserName("htmlunit");
         return capabilities;
     }
 


### PR DESCRIPTION
Currently, the browser name is missing which leads HtmlUnit to fail:
https://groups.google.com/forum/#!topic/jmeter-plugins/lMcNMGSS4as

See https://github.com/SeleniumHQ/htmlunit-driver/commit/f9bca6d172d215f9e66c4aac021869cc5e9791cd for the error handling part in htmlUnit