### PR TITLE
Update chromedriver config file

### DIFF
--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
@@ -53,6 +53,8 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
             }
             if (isHeadlessEnabled()) {
                 chromeOptions.addArguments("--headless");
+		//Adding the options to whitelist all IPs to allow the WebDriverSampler to call ChromeDriver from Docker in headless mode
+		chromeOptions.addArguments("--whitelisted-ips");
 
             }
             capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);


### PR DESCRIPTION
Adding the chromeOptions.addArguments("--whitelisted-ips"); option to allow the WDS to invoke the chrome driver in headless mode in a docker container. When this is not set, I get the below error 
Starting the test @ Fri Aug 23 08:35:04 UTC 2019 (1566549304870)
Waiting for possible Shutdown/StopTestNow/HeapDump/ThreadDump message on port 4445
Starting ChromeDriver 2.40.565383 (76257d1ab79276b2d53ee976b2c3e3b9f335cde7) on port 18141
Only local connections are allowed.
[1566549306.803][SEVERE]: bind() returned an error, errno=99: Cannot assign requested address (99)
summary +      2 in 00:01:57 =    0.0/s Avg:    23 Min:    12 Max:    35 Err:     0 (0.00%) Active: 1 Started: 1 Finished: 0
summary +      5 in 00:04:00 =    0.0/s Avg:    12 Min:    11 Max:    14 Err:     0 (0.00%) Active: 1 Started: 1 Finished: 0