### PR TITLE
Updated Java and Selenium Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <selenium.version>3.14.0</selenium.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <selenium.version>3.141.59</selenium.version>
     </properties>
 
     <build>


### PR DESCRIPTION
The current Selenium version is 3.141.59 (as of 2020-04/16), and the current legacy LTS Java version is 1.8. By now *everyone* is running either Java 1.8 or newer since 1.6 and 1.7 have been EOL'd for a while already. It should be safe to move up and those who can't can remain with the old(er) Selenium and plugin binaries without issue.