### PR TITLE
Add ChromeDriver no sandbox option

### DIFF
--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
@@ -27,6 +27,7 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
     private static final String HEADLESS_ENABLED = "ChromeDriverConfig.headless_enabled";
     private static final String INSECURECERTS_ENABLED = "ChromeDriverConfig.insecurecerts_enabled";
     private static final String INCOGNITO_ENABLED = "ChromeDriverConfig.incognito_enabled";
+    private static final String NO_SANDBOX_ENABLED = "ChromeDriverConfig.no_sandbox_enabled";
     private static final Map<String, ChromeDriverService> services = new ConcurrentHashMap<String, ChromeDriverService>();
 
     public void setChromeDriverPath(String path) {
@@ -45,7 +46,7 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
 		capabilities.setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
         
 
-        if(isAndroidEnabled() || isHeadlessEnabled() || isIncognitoEnabled()) {
+        if(isAndroidEnabled() || isHeadlessEnabled() || isIncognitoEnabled() || isNoSandboxEnabled()) {
             //Map<String, String> chromeOptions = new HashMap<String, String>();
             //chromeOptions.put("androidPackage", "com.android.chrome");
             ChromeOptions chromeOptions = new ChromeOptions();
@@ -54,11 +55,13 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
             }
             if (isHeadlessEnabled()) {
                 chromeOptions.addArguments("--headless");
+            }
+            if (isNoSandboxEnabled()) {
+                chromeOptions.addArguments("--no-sandbox");
 
             }
             if (isIncognitoEnabled()) {
                 chromeOptions.addArguments("--incognito");
-
             }
             capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
         }
@@ -137,4 +140,9 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
         setProperty(INCOGNITO_ENABLED, enabled);
     }
 
+    public boolean isNoSandboxEnabled() {
+        return getPropertyAsBoolean(NO_SANDBOX_ENABLED);
+    }
+
+    public void setNoSandboxEnabled(boolean enabled) { setProperty(NO_SANDBOX_ENABLED, enabled); }
 }

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGui.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGui.java
@@ -16,6 +16,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
     private JCheckBox headlessEnabled;
     private JCheckBox insecureCertsEnabled;
     private JCheckBox incognitoEnabled;
+    private JCheckBox noSandboxEnabled;
 
     @Override
     public String getStaticLabel() {
@@ -37,6 +38,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
             getHeadlessEnabled().setSelected(config.isHeadlessEnabled());
             getInsecureCertsEnabled().setSelected(config.isInsecureCertsEnabled());
             getIncognitoEnabled().setSelected(config.isIncognitoEnabled());
+            getNoSandboxEnabled().setSelected(config.isNoSandboxEnabled());
         }
     }
 
@@ -57,6 +59,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
             config.setHeadlessEnabled(getHeadlessEnabled().isSelected());
             config.setInsecureCertsEnabled(getInsecureCertsEnabled().isSelected());
             config.setIncognitoEnabled(getIncognitoEnabled().isSelected());
+            config.setNoSandboxEnabled(getNoSandboxEnabled().isSelected());
         }
     }
 
@@ -68,6 +71,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
         getHeadlessEnabled().setSelected(false);
         getInsecureCertsEnabled().setSelected(false);
         getIncognitoEnabled().setSelected(false);
+        getNoSandboxEnabled().setSelected(false);
     }
 
     @Override
@@ -106,6 +110,10 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
 
         incognitoEnabled = new JCheckBox("Run in Incognito mode");
         browserPanel.add(getIncognitoEnabled());
+
+        noSandboxEnabled = new JCheckBox("Run in No sandbox mode");
+        browserPanel.add(getNoSandboxEnabled());
+
         return browserPanel;
     }
 
@@ -129,5 +137,9 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
 
     public JCheckBox getIncognitoEnabled() {
         return incognitoEnabled;
+    }
+
+    public JCheckBox getNoSandboxEnabled() {
+        return noSandboxEnabled;
     }
 }

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -214,4 +214,11 @@ public class ChromeDriverConfigTest {
         config.setIncognitoEnabled(true);
         assertThat(config.isIncognitoEnabled(), is(true));
     }
+
+    @Test
+    public void getSetNoSandboxEnabled() {
+        assertThat(config.isNoSandboxEnabled(), is(false));
+        config.setNoSandboxEnabled(true);
+        assertThat(config.isNoSandboxEnabled(), is(true));
+    }
 }

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGuiTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGuiTest.java
@@ -79,12 +79,20 @@ public class ChromeDriverConfigGuiTest {
     }
 
     @Test
+    public void shouldSetNoSandboxEnabled() {
+        gui.getNoSandboxEnabled().setSelected(true);
+        final ChromeDriverConfig testElement = (ChromeDriverConfig) gui.createTestElement();
+        assertThat(testElement.isNoSandboxEnabled(), is(true));
+    }
+
+    @Test
     public void shouldResetValuesOnClearGui() {
         gui.chromeServicePath.setText("path");
         gui.androidEnabled.setSelected(true);
         gui.getHeadlessEnabled().setSelected(true);
         gui.getInsecureCertsEnabled().setSelected(true);
         gui.getIncognitoEnabled().setSelected(true);
+        gui.getNoSandboxEnabled().setSelected(true);
 
         gui.clearGui();
 
@@ -93,6 +101,7 @@ public class ChromeDriverConfigGuiTest {
         assertThat(gui.getHeadlessEnabled().isSelected(), is(false));
         assertThat(gui.getInsecureCertsEnabled().isSelected(), is(false));
         assertThat(gui.getIncognitoEnabled().isSelected(), is(false));
+        assertThat(gui.getNoSandboxEnabled().isSelected(), is(false));
     }
 
     @Test
@@ -146,4 +155,12 @@ public class ChromeDriverConfigGuiTest {
 		assertThat(gui.isProxyEnabled(), is(true));
 	}
 
+    @Test
+    public void shouldSetNoSandboxEnabledOnConfigure() {
+        ChromeDriverConfig config = new ChromeDriverConfig();
+        config.setNoSandboxEnabled(true);
+        gui.configure(config);
+
+        assertThat(gui.getNoSandboxEnabled().isSelected(), is(config.isNoSandboxEnabled()));
+    }
 }


### PR DESCRIPTION
Add ChromeDriver no sandbox option for JMeter inside Docker without admin capability (more infos here : https://github.com/Zenika/alpine-chrome#3-ways-to-securely-use-chrome-headless-with-this-image)