### PR TITLE
Enhancements for Headless Firefox, among other cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-webdriver</artifactId>
-    <version>3.1</version>
+    <version>3.4</version>
 
     <name>WebDriver/Selenium</name>
     <description>WebDriver/Selenium</description>
@@ -17,9 +17,9 @@
     </licenses>
     <url>http://jmeter-plugins.org/</url>
     <scm>
-        <url>https://github.com/undera/jmeter-plugins</url>
-        <connection>https://github.com/undera/jmeter-plugins.git</connection>
-        <developerConnection>git@github.com:undera/jmeter-plugins.git</developerConnection>
+        <url>https://github.com/undera/jmeter-plugins-webdriver</url>
+        <connection>https://github.com/undera/jmeter-plugins-webdriver.git</connection>
+        <developerConnection>git@github.com:undera/jmeter-plugins-webdriver.git</developerConnection>
     </scm>
     <developers>
         <developer>

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
@@ -25,6 +25,7 @@ public class FirefoxDriverConfig extends WebDriverConfig<FirefoxDriver> {
     private static final long serialVersionUID = 100L;
     private static final String GENERAL_USERAGENT_OVERRIDE = "FirefoxDriverConfig.general.useragent.override";
     private static final String ENABLE_USERAGENT_OVERRIDE = "FirefoxDriverConfig.general.useragent.override.enabled";
+    private static final String ENABLE_HEADLESS = "FirefoxDriverConfig.general.headless.enabled";
     private static final String ENABLE_NTML = "FirefoxDriverConfig.network.negotiate-auth.allow-insecure-ntlm-v1";
     private static final String EXTENSIONS_TO_LOAD = "FirefoxDriverConfig.general.extensions";
     private static final String PREFERENCES = "FirefoxDriverConfig.general.preferences";
@@ -96,8 +97,20 @@ public class FirefoxDriverConfig extends WebDriverConfig<FirefoxDriver> {
     protected FirefoxDriver createBrowser() {
         FirefoxOptions desiredCapabilities = new FirefoxOptions(createCapabilities());
         desiredCapabilities.setCapability(FirefoxDriver.PROFILE, createProfile());
-        return new FirefoxDriver(new GeckoDriverService.Builder().usingFirefoxBinary(new FirefoxBinary()).build(),
+        FirefoxBinary binary = new FirefoxBinary();
+        if (isHeadless()) {
+            binary.addCommandLineOptions("--headless");
+        }
+        return new FirefoxDriver(new GeckoDriverService.Builder().usingFirefoxBinary(binary).build(),
                 desiredCapabilities);
+    }
+
+    public boolean isHeadless() {
+        return getPropertyAsBoolean(ENABLE_HEADLESS);
+    }
+
+    public void setHeadless(boolean headless) {
+        setProperty(ENABLE_HEADLESS, headless);
     }
 
     public void setUserAgentOverride(String userAgent) {

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
@@ -97,11 +97,8 @@ public class FirefoxDriverConfig extends WebDriverConfig<FirefoxDriver> {
     protected FirefoxDriver createBrowser() {
         FirefoxOptions desiredCapabilities = new FirefoxOptions(createCapabilities());
         desiredCapabilities.setCapability(FirefoxDriver.PROFILE, createProfile());
-        FirefoxBinary binary = new FirefoxBinary();
-        if (isHeadless()) {
-            binary.addCommandLineOptions("--headless");
-        }
-        return new FirefoxDriver(new GeckoDriverService.Builder().usingFirefoxBinary(binary).build(),
+        desiredCapabilities.setHeadless(isHeadless());
+        return new FirefoxDriver(new GeckoDriverService.Builder().usingFirefoxBinary(new FirefoxBinary()).build(),
                 desiredCapabilities);
     }
 

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfig.java
@@ -25,7 +25,9 @@ public class FirefoxDriverConfig extends WebDriverConfig<FirefoxDriver> {
     private static final long serialVersionUID = 100L;
     private static final String GENERAL_USERAGENT_OVERRIDE = "FirefoxDriverConfig.general.useragent.override";
     private static final String ENABLE_USERAGENT_OVERRIDE = "FirefoxDriverConfig.general.useragent.override.enabled";
-    private static final String ENABLE_HEADLESS = "FirefoxDriverConfig.general.headless.enabled";
+    private static final String ENABLE_LEGACY = "FirefoxDriverConfig.general.legacy";
+    private static final String ENABLE_ACCEPT_INSECURE_CERTS = "FirefoxDriverConfig.general.accept-insecure-certs";
+    private static final String ENABLE_HEADLESS = "FirefoxDriverConfig.general.headless";
     private static final String ENABLE_NTML = "FirefoxDriverConfig.network.negotiate-auth.allow-insecure-ntlm-v1";
     private static final String EXTENSIONS_TO_LOAD = "FirefoxDriverConfig.general.extensions";
     private static final String PREFERENCES = "FirefoxDriverConfig.general.preferences";
@@ -98,8 +100,26 @@ public class FirefoxDriverConfig extends WebDriverConfig<FirefoxDriver> {
         FirefoxOptions desiredCapabilities = new FirefoxOptions(createCapabilities());
         desiredCapabilities.setCapability(FirefoxDriver.PROFILE, createProfile());
         desiredCapabilities.setHeadless(isHeadless());
+        desiredCapabilities.setAcceptInsecureCerts(isAcceptInsecureCerts());
+        desiredCapabilities.setLegacy(isLegacy());
         return new FirefoxDriver(new GeckoDriverService.Builder().usingFirefoxBinary(new FirefoxBinary()).build(),
                 desiredCapabilities);
+    }
+
+    public boolean isLegacy() {
+        return getPropertyAsBoolean(ENABLE_LEGACY);
+    }
+
+    public void setLegacy(boolean legacy) {
+        setProperty(ENABLE_LEGACY, legacy);
+    }
+
+    public boolean isAcceptInsecureCerts() {
+        return getPropertyAsBoolean(ENABLE_ACCEPT_INSECURE_CERTS);
+    }
+
+    public void setAcceptInsecureCerts(boolean acceptInsecureCerts) {
+        setProperty(ENABLE_ACCEPT_INSECURE_CERTS, acceptInsecureCerts);
     }
 
     public boolean isHeadless() {

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/FirefoxDriverConfigGui.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/FirefoxDriverConfigGui.java
@@ -17,6 +17,8 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
 
     private static final long serialVersionUID = 100L;
     JTextField userAgentOverrideText;
+    JCheckBox legacyCheckbox;
+    JCheckBox acceptInsecureCertsCheckbox;
     JCheckBox headlessCheckbox;
     JCheckBox userAgentOverrideCheckbox;
     JCheckBox ntlmOverrideCheckbox;
@@ -60,6 +62,8 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
         super.configure(element);
         if (element instanceof FirefoxDriverConfig) {
             FirefoxDriverConfig config = (FirefoxDriverConfig) element;
+            legacyCheckbox.setSelected(config.isLegacy());
+            acceptInsecureCertsCheckbox.setSelected(config.isAcceptInsecureCerts());
             headlessCheckbox.setSelected(config.isHeadless());
             userAgentOverrideCheckbox.setSelected(config.isUserAgentOverridden());
             userAgentOverrideText.setText(config.getUserAgentOverride());
@@ -82,6 +86,8 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
         super.modifyTestElement(element);
         if (element instanceof FirefoxDriverConfig) {
             FirefoxDriverConfig config = (FirefoxDriverConfig) element;
+            config.setLegacy(legacyCheckbox.isSelected());
+            config.setAcceptInsecureCerts(acceptInsecureCertsCheckbox.isSelected());
             config.setHeadless(headlessCheckbox.isSelected());
             config.setUserAgentOverridden(userAgentOverrideCheckbox.isSelected());
             config.setNtlmSetting(ntlmOverrideCheckbox.isSelected());
@@ -95,10 +101,19 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
 
     private JPanel createProfilePanel() {
         final JPanel firefoxPanel = new VerticalPanel();
-        headlessCheckbox = new JCheckBox("Headless mode");
+        legacyCheckbox = new JCheckBox("Legacy mode");
+        legacyCheckbox.setSelected(false);
+        legacyCheckbox.setEnabled(true);
+        firefoxPanel.add(legacyCheckbox);
+
+        acceptInsecureCertsCheckbox = new JCheckBox("Accept Insecure Certificates");
+        acceptInsecureCertsCheckbox.setSelected(false);
+        acceptInsecureCertsCheckbox.setEnabled(true);
+        firefoxPanel.add(acceptInsecureCertsCheckbox);
+
+        headlessCheckbox = new JCheckBox("Headless");
         headlessCheckbox.setSelected(false);
         headlessCheckbox.setEnabled(true);
-        headlessCheckbox.addItemListener(this);
         firefoxPanel.add(headlessCheckbox);
 
         userAgentOverrideCheckbox = new JCheckBox("Override User Agent");

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/FirefoxDriverConfigGui.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/FirefoxDriverConfigGui.java
@@ -17,6 +17,7 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
 
     private static final long serialVersionUID = 100L;
     JTextField userAgentOverrideText;
+    JCheckBox headlessCheckbox;
     JCheckBox userAgentOverrideCheckbox;
     JCheckBox ntlmOverrideCheckbox;
     private Grid extensions;
@@ -59,6 +60,7 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
         super.configure(element);
         if (element instanceof FirefoxDriverConfig) {
             FirefoxDriverConfig config = (FirefoxDriverConfig) element;
+            headlessCheckbox.setSelected(config.isHeadless());
             userAgentOverrideCheckbox.setSelected(config.isUserAgentOverridden());
             userAgentOverrideText.setText(config.getUserAgentOverride());
             userAgentOverrideText.setEnabled(config.isUserAgentOverridden());
@@ -80,6 +82,7 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
         super.modifyTestElement(element);
         if (element instanceof FirefoxDriverConfig) {
             FirefoxDriverConfig config = (FirefoxDriverConfig) element;
+            config.setHeadless(headlessCheckbox.isSelected());
             config.setUserAgentOverridden(userAgentOverrideCheckbox.isSelected());
             config.setNtlmSetting(ntlmOverrideCheckbox.isSelected());
             if (userAgentOverrideCheckbox.isSelected()) {
@@ -92,6 +95,12 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
 
     private JPanel createProfilePanel() {
         final JPanel firefoxPanel = new VerticalPanel();
+        headlessCheckbox = new JCheckBox("Headless mode");
+        headlessCheckbox.setSelected(false);
+        headlessCheckbox.setEnabled(true);
+        headlessCheckbox.addItemListener(this);
+        firefoxPanel.add(headlessCheckbox);
+
         userAgentOverrideCheckbox = new JCheckBox("Override User Agent");
         userAgentOverrideCheckbox.setSelected(false);
         userAgentOverrideCheckbox.setEnabled(true);
@@ -122,6 +131,7 @@ public class FirefoxDriverConfigGui extends WebDriverConfigGui implements ItemLi
     @Override
     public void clearGui() {
         super.clearGui();
+        headlessCheckbox.setSelected(false);
         userAgentOverrideCheckbox.setSelected(false);
         userAgentOverrideText.setText("");
         ntlmOverrideCheckbox.setSelected(false);


### PR DESCRIPTION
Headless Firefox support turned out to be trivial, so it was added, along with two other flags that might be useful. Some POM fixups as well. Tested and verified working.