### PR TITLE
Feature/add chromedriver options

### DIFF
--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
@@ -28,6 +28,7 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
     private static final String INSECURECERTS_ENABLED = "ChromeDriverConfig.insecurecerts_enabled";
     private static final String INCOGNITO_ENABLED = "ChromeDriverConfig.incognito_enabled";
     private static final String NO_SANDBOX_ENABLED = "ChromeDriverConfig.no_sandbox_enabled";
+    private static final String ADDITIONAL_ARGS = "ChromeDriverConfig.additional_args";
     private static final Map<String, ChromeDriverService> services = new ConcurrentHashMap<String, ChromeDriverService>();
 
     public void setChromeDriverPath(String path) {
@@ -45,8 +46,8 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
 		logPrefs.enable(LogType.BROWSER, Level.ALL);
 		capabilities.setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
         
-
-        if(isAndroidEnabled() || isHeadlessEnabled() || isIncognitoEnabled() || isNoSandboxEnabled()) {
+        final String additionalArgs = trimmed(getAdditionalArgs());
+        if(isAndroidEnabled() || isHeadlessEnabled() || isIncognitoEnabled() || isNoSandboxEnabled() || (null != additionalArgs && !additionalArgs.isEmpty())) {
             //Map<String, String> chromeOptions = new HashMap<String, String>();
             //chromeOptions.put("androidPackage", "com.android.chrome");
             ChromeOptions chromeOptions = new ChromeOptions();
@@ -63,6 +64,9 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
             if (isIncognitoEnabled()) {
                 chromeOptions.addArguments("--incognito");
             }
+            if(null != additionalArgs && !additionalArgs.isEmpty()) {
+                chromeOptions.addArguments(additionalArgs.split("\\s+"));
+            }
             capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
         }
 
@@ -71,6 +75,10 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
         }
 
         return capabilities;
+    }
+
+    private String trimmed(String str) {
+        return null == str ? null : str.trim();
     }
 
     Map<String, ChromeDriverService> getServices() {
@@ -145,4 +153,13 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
     }
 
     public void setNoSandboxEnabled(boolean enabled) { setProperty(NO_SANDBOX_ENABLED, enabled); }
+
+    public String getAdditionalArgs() {
+        return getPropertyAsString(ADDITIONAL_ARGS);
+    }
+
+    public void setAdditionalArgs(String additionalArgs) {
+        setProperty(ADDITIONAL_ARGS, additionalArgs);
+    }
+
 }

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfig.java
@@ -13,7 +13,6 @@ import org.openqa.selenium.logging.LogType;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -29,6 +28,8 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
     private static final String INCOGNITO_ENABLED = "ChromeDriverConfig.incognito_enabled";
     private static final String NO_SANDBOX_ENABLED = "ChromeDriverConfig.no_sandbox_enabled";
     private static final String ADDITIONAL_ARGS = "ChromeDriverConfig.additional_args";
+    private static final String BINARY_PATH = "ChromeDriverConfig.binary_path";
+
     private static final Map<String, ChromeDriverService> services = new ConcurrentHashMap<String, ChromeDriverService>();
 
     public void setChromeDriverPath(String path) {
@@ -39,6 +40,14 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
         return getPropertyAsString(CHROME_SERVICE_PATH);
     }
 
+    public void setBinaryPath(String binaryPath) {
+        setProperty(BINARY_PATH, binaryPath);
+    }
+
+    public String getBinaryPath() {
+        return getPropertyAsString(BINARY_PATH);
+    }
+
     Capabilities createCapabilities() {
         DesiredCapabilities capabilities = new DesiredCapabilities();
         capabilities.setCapability(CapabilityType.PROXY, createProxy());
@@ -47,7 +56,8 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
 		capabilities.setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
         
         final String additionalArgs = trimmed(getAdditionalArgs());
-        if(isAndroidEnabled() || isHeadlessEnabled() || isIncognitoEnabled() || isNoSandboxEnabled() || (null != additionalArgs && !additionalArgs.isEmpty())) {
+        final String binaryPath = trimmed(getBinaryPath());
+        if(isAndroidEnabled() || isHeadlessEnabled() || isIncognitoEnabled() || isNoSandboxEnabled() || (null != additionalArgs && !additionalArgs.isEmpty()) || (null != binaryPath && !binaryPath.isEmpty())) {
             //Map<String, String> chromeOptions = new HashMap<String, String>();
             //chromeOptions.put("androidPackage", "com.android.chrome");
             ChromeOptions chromeOptions = new ChromeOptions();
@@ -66,6 +76,9 @@ public class ChromeDriverConfig extends WebDriverConfig<ChromeDriver> {
             }
             if(null != additionalArgs && !additionalArgs.isEmpty()) {
                 chromeOptions.addArguments(additionalArgs.split("\\s+"));
+            }
+            if(null != binaryPath && !binaryPath.isEmpty()) {
+                chromeOptions.setBinary(binaryPath);
             }
             capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
         }

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGui.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGui.java
@@ -18,6 +18,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
     private JCheckBox incognitoEnabled;
     private JCheckBox noSandboxEnabled;
     JTextField additionalArgs;
+    JTextField binaryPath;
 
     @Override
     public String getStaticLabel() {
@@ -41,6 +42,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
             getIncognitoEnabled().setSelected(config.isIncognitoEnabled());
             getNoSandboxEnabled().setSelected(config.isNoSandboxEnabled());
             additionalArgs.setText(config.getAdditionalArgs());
+            binaryPath.setText(config.getBinaryPath());
         }
     }
 
@@ -63,6 +65,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
             config.setIncognitoEnabled(getIncognitoEnabled().isSelected());
             config.setNoSandboxEnabled(getNoSandboxEnabled().isSelected());
             config.setAdditionalArgs(additionalArgs.getText());
+            config.setBinaryPath(binaryPath.getText());
         }
     }
 
@@ -76,6 +79,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
         getIncognitoEnabled().setSelected(false);
         getNoSandboxEnabled().setSelected(false);
         additionalArgs.setText("");
+        binaryPath.setText("");
     }
 
     @Override
@@ -102,6 +106,13 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
         chromeServicePath = new JTextField();
         chromeServicePanel.add(chromeServicePath);
         browserPanel.add(chromeServicePanel);
+
+        final JPanel binaryPathPanel = new HorizontalPanel();
+        final JLabel binaryPathLabel = new JLabel("Binary path");
+        binaryPath = new JTextField();
+        binaryPathPanel.add(binaryPathLabel);
+        binaryPathPanel.add(binaryPath);
+        browserPanel.add(binaryPathPanel);
 
         androidEnabled = new JCheckBox("Use Chrome on Android");
         browserPanel.add(androidEnabled);

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGui.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGui.java
@@ -17,6 +17,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
     private JCheckBox insecureCertsEnabled;
     private JCheckBox incognitoEnabled;
     private JCheckBox noSandboxEnabled;
+    JTextField additionalArgs;
 
     @Override
     public String getStaticLabel() {
@@ -39,6 +40,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
             getInsecureCertsEnabled().setSelected(config.isInsecureCertsEnabled());
             getIncognitoEnabled().setSelected(config.isIncognitoEnabled());
             getNoSandboxEnabled().setSelected(config.isNoSandboxEnabled());
+            additionalArgs.setText(config.getAdditionalArgs());
         }
     }
 
@@ -60,6 +62,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
             config.setInsecureCertsEnabled(getInsecureCertsEnabled().isSelected());
             config.setIncognitoEnabled(getIncognitoEnabled().isSelected());
             config.setNoSandboxEnabled(getNoSandboxEnabled().isSelected());
+            config.setAdditionalArgs(additionalArgs.getText());
         }
     }
 
@@ -72,6 +75,7 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
         getInsecureCertsEnabled().setSelected(false);
         getIncognitoEnabled().setSelected(false);
         getNoSandboxEnabled().setSelected(false);
+        additionalArgs.setText("");
     }
 
     @Override
@@ -91,10 +95,10 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
 
     private JPanel createServicePanel() {
         final JPanel browserPanel = new VerticalPanel();
+
         final JPanel chromeServicePanel = new HorizontalPanel();
         final JLabel chromeDriverServiceLabel = new JLabel("Path to Chrome Driver");
         chromeServicePanel.add(chromeDriverServiceLabel);
-
         chromeServicePath = new JTextField();
         chromeServicePanel.add(chromeServicePath);
         browserPanel.add(chromeServicePanel);
@@ -113,6 +117,13 @@ public class ChromeDriverConfigGui extends WebDriverConfigGui {
 
         noSandboxEnabled = new JCheckBox("Run in No sandbox mode");
         browserPanel.add(getNoSandboxEnabled());
+
+        final JPanel additionalArgsPanel = new HorizontalPanel();
+        final JLabel additionalArgsLabel = new JLabel("Additional arguments");
+        additionalArgs = new JTextField();
+        additionalArgsPanel.add(additionalArgsLabel);
+        additionalArgsPanel.add(additionalArgs);
+        browserPanel.add(additionalArgsPanel);
 
         return browserPanel;
     }

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -207,6 +207,12 @@ public class ChromeDriverConfigTest {
     }
 
     @Test
+    public void getSetBinaryPath() {
+        config.setBinaryPath("some/path");
+        assertThat(config.getBinaryPath(), is("some/path"));
+    }
+
+    @Test
     public void getSetAndroidEnabled() {
         assertThat(config.isAndroidEnabled(), is(false));
         config.setAndroidEnabled(true);

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -240,4 +240,10 @@ public class ChromeDriverConfigTest {
         config.setNoSandboxEnabled(true);
         assertThat(config.isNoSandboxEnabled(), is(true));
     }
+
+    @Test
+    public void getSetAdditionalArgs() {
+        config.setAdditionalArgs("additional args");
+        assertThat(config.getAdditionalArgs(), is("additional args"));
+    }
 }

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGuiTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGuiTest.java
@@ -86,6 +86,13 @@ public class ChromeDriverConfigGuiTest {
     }
 
     @Test
+    public void shouldSetAdditionalArgs() {
+        gui.additionalArgs.setText("additionalArgs");
+        final ChromeDriverConfig testElement = (ChromeDriverConfig) gui.createTestElement();
+        assertThat(testElement.getAdditionalArgs(), is("additionalArgs"));
+    }
+
+    @Test
     public void shouldResetValuesOnClearGui() {
         gui.chromeServicePath.setText("path");
         gui.androidEnabled.setSelected(true);
@@ -93,6 +100,7 @@ public class ChromeDriverConfigGuiTest {
         gui.getInsecureCertsEnabled().setSelected(true);
         gui.getIncognitoEnabled().setSelected(true);
         gui.getNoSandboxEnabled().setSelected(true);
+        gui.additionalArgs.setText("additional");
 
         gui.clearGui();
 
@@ -102,6 +110,7 @@ public class ChromeDriverConfigGuiTest {
         assertThat(gui.getInsecureCertsEnabled().isSelected(), is(false));
         assertThat(gui.getIncognitoEnabled().isSelected(), is(false));
         assertThat(gui.getNoSandboxEnabled().isSelected(), is(false));
+        assertThat(gui.additionalArgs.getText(), is(""));
     }
 
     @Test
@@ -163,4 +172,14 @@ public class ChromeDriverConfigGuiTest {
 
         assertThat(gui.getNoSandboxEnabled().isSelected(), is(config.isNoSandboxEnabled()));
     }
+
+    @Test
+    public void shouldSetAdditionalArgsOnConfigure() {
+        ChromeDriverConfig config = new ChromeDriverConfig();
+        config.setAdditionalArgs("chromedriver.additional_args");
+        gui.configure(config);
+
+        assertThat(gui.additionalArgs.getText(), is(config.getAdditionalArgs()));
+    }
+
 }

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGuiTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/ChromeDriverConfigGuiTest.java
@@ -95,6 +95,7 @@ public class ChromeDriverConfigGuiTest {
     @Test
     public void shouldResetValuesOnClearGui() {
         gui.chromeServicePath.setText("path");
+        gui.binaryPath.setText("path/binary");
         gui.androidEnabled.setSelected(true);
         gui.getHeadlessEnabled().setSelected(true);
         gui.getInsecureCertsEnabled().setSelected(true);
@@ -104,6 +105,7 @@ public class ChromeDriverConfigGuiTest {
 
         gui.clearGui();
 
+        assertThat(gui.chromeServicePath.getText(), is(""));
         assertThat(gui.chromeServicePath.getText(), is(""));
         assertThat(gui.androidEnabled.isSelected(), is(false));
         assertThat(gui.getHeadlessEnabled().isSelected(), is(false));
@@ -120,6 +122,15 @@ public class ChromeDriverConfigGuiTest {
         gui.configure(config);
 
         assertThat(gui.chromeServicePath.getText(), is(config.getChromeDriverPath()));
+    }
+
+    @Test
+    public void shouldSetBinaryPathOnConfigure() {
+        ChromeDriverConfig config = new ChromeDriverConfig();
+        config.setBinaryPath("chromedriver.binary_path");
+        gui.configure(config);
+
+        assertThat(gui.binaryPath.getText(), is(config.getBinaryPath()));
     }
 
     @Test


### PR DESCRIPTION
Add the ability to specify the chrome binary and additional arguments for the ChromeDriver.

Setting the chrome binary is especially useful when working with different chrome versions (chrome portable) and thus not relying on the system wide installation.