### PR TITLE
Feature/Add custom webdriver capabilites

### DIFF
--- a/DirectDriverConfig.wiki
+++ b/DirectDriverConfig.wiki
@@ -16,10 +16,11 @@ For Internet Explorer, the system will start Edge in "IE Mode" as Internet Explo
 HtmlUnit is a good compromise between speed of execution and the CPU usage per thread while maintaining Selenium API.
 The main drawback is that there is no screen so it's more difficult to understand the cause of problems and also that the javascript engine is not powerful as browsers such Firefox or Chrome.
 
-The configuration of eacḣ browser follows the same principle and is divided across three different tabs:
+The configuration of eacḣ browser follows the same principle and is divided across four different tabs:
 * the Driver tab;
 * the Options tab;
 * the Proxy tab;
+* the Capabilities Management tab;
 
 == Driver Tab ==
 === Install Drivers ===
@@ -60,6 +61,15 @@ You can find information on the other options presented in this tab at [https://
 
 == Proxy Tab ==
 The default configuration (Use system proxy) is suitable for most. However, if you are in a corporate environment and a browser fails to connect to a URL, this is most likely because the environmemt needs a proxy to be accessed.
+
+== Capabilties Management Tab ==
+This tab enables custom webdriver capability configuration using Json as input.
+These custom capabilities are appended after the browser options configured from all other tabs.
+These capabilities are appeneded to both "capabilities" and/or "desiredCapabilities" as allowed by webdriver.
+
+This is especically useful when using webdriver W3C extension capabilites, which allow more advanced/custom webdriver requests. See https://www.w3.org/TR/webdriver1/#dfn-extension-capability
+
+Example: Some webdriver requests require vendor specific capabilities (eg: authentication). This enables that.
 
 === No proxy ===
 Use this option if you directly connect to the internet, and your network will not make use of any proxies.  

--- a/RemoteDriverConfig.wiki
+++ b/RemoteDriverConfig.wiki
@@ -25,11 +25,8 @@ Once you have selected the browser in the Capability list box, navigate to the a
 
 For more information on the options, please refer to [[DirectDriverConfig.wiki#Options Tab|Options Tab]] in the Direct Driver wiki page.
 
-== Capabilties Management Tab ==
-This tab enables custom webdriver capability configuration using Json as input.
-These custom capabilities are appended after the browser options configured from all other tabs.
-
-This is especically useful when using webdriver W3C capabilites, which allow more advanced/custom webdriver requests.
-
 == Proxy Tab ==
 Please see the [[DirectDriverConfig.wiki#Proxy Tab|Proxy Tab]] in the Direct Driver wiki page for more information on the Proxy settings of browser.
+
+== Capabilties Management Tab ==
+Please see the [[DirectDriverConfig.wiki#Capabilties Management Tab|Capabilties Management Tab]] in the Direct Driver wiki page for more information on configuring custom webdriver capabilties.

--- a/RemoteDriverConfig.wiki
+++ b/RemoteDriverConfig.wiki
@@ -25,5 +25,11 @@ Once you have selected the browser in the Capability list box, navigate to the a
 
 For more information on the options, please refer to [[DirectDriverConfig.wiki#Options Tab|Options Tab]] in the Direct Driver wiki page.
 
+== Capabilties Management Tab ==
+This tab enables custom webdriver capability configuration using Json as input.
+These custom capabilities are appended after the browser options configured from all other tabs.
+
+This is especically useful when using webdriver W3C capabilites, which allow more advanced/custom webdriver requests.
+
 == Proxy Tab ==
 Please see the [[DirectDriverConfig.wiki#Proxy Tab|Proxy Tab]] in the Direct Driver wiki page for more information on the Proxy settings of browser.

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
             <artifactId>httpmime</artifactId>
             <version>4.5.14</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.14.2</version>
+        </dependency>
         <!--
         <dependency>
 	       <groupId>org.w3c.css</groupId>

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/HtmlUnitDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/HtmlUnitDriverConfig.java
@@ -14,6 +14,7 @@ public class HtmlUnitDriverConfig extends WebDriverConfig<HtmlUnitDriver> {
         capabilities.setBrowserName("htmlunit");
         capabilities.setAcceptInsecureCerts(isAcceptInsecureCerts());
         capabilities.setCapability(CapabilityType.PROXY, createProxy());
+        combineCustomCapabilities(capabilities);
         return capabilities;
     }
 

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteBrowser.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteBrowser.java
@@ -1,6 +1,6 @@
 package com.googlecode.jmeter.plugins.webdriver.config;
 
-public enum RemoteCapability {
+public enum RemoteBrowser {
 	CHROME,
 	EDGE,
 	FIREFOX,

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfig.java
@@ -16,7 +16,7 @@ public class RemoteDriverConfig extends WebDriverConfig<RemoteWebDriver> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteDriverConfig.class);
 
 	private static final String LOCAL_FILE_DETECTOR = "RemoteDriverConfig.general.selenium.file.detector";
-	private static final String REMOTE_CAPABILITY = "RemoteDriverConfig.general.selenium.capability";
+	private static final String REMOTE_BROWSER = "RemoteDriverConfig.general.selenium.capability";
 	private static final String REMOTE_SELENIUM_GRID_URL = "RemoteDriverConfig.general.selenium.grid.url";
 
 	@Override
@@ -33,10 +33,10 @@ public class RemoteDriverConfig extends WebDriverConfig<RemoteWebDriver> {
 		}
 	}
 
-	Capabilities createCapabilities() {
+	public Capabilities createCapabilities() {
 		// We pass the browser option instance to the remote so it knows which browser to use
 		AbstractDriverOptions<?> caps = null;
-		switch (getCapability()) {
+		switch (getSelectedBrowser()) {
 		case CHROME:
 			caps = createChromeOptions();
 			break;
@@ -52,14 +52,15 @@ public class RemoteDriverConfig extends WebDriverConfig<RemoteWebDriver> {
 		default:
 			throw new IllegalArgumentException("No such capability");
 		}
+		combineCustomCapabilities(caps);
 		return caps;
 	}
 
-	public RemoteCapability getCapability() {
-		return RemoteCapability.valueOf(getPropertyAsString(REMOTE_CAPABILITY));
+	public RemoteBrowser getSelectedBrowser() {
+		return RemoteBrowser.valueOf(getPropertyAsString(REMOTE_BROWSER));
 	}
-	public void setCapability(RemoteCapability selectedCapability) {
-		setProperty(REMOTE_CAPABILITY, selectedCapability.name());
+	public void setSelectedBrowser(RemoteBrowser remoteBrowser) {
+		setProperty(REMOTE_BROWSER, remoteBrowser.name());
 	}
 
 	public String getSeleniumGridUrl() {

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGui.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGui.java
@@ -3,7 +3,7 @@ package com.googlecode.jmeter.plugins.webdriver.config.gui;
 import org.apache.commons.lang.StringUtils;
 import org.apache.jmeter.testelement.TestElement;
 
-import com.googlecode.jmeter.plugins.webdriver.config.RemoteCapability;
+import com.googlecode.jmeter.plugins.webdriver.config.RemoteBrowser;
 import com.googlecode.jmeter.plugins.webdriver.config.RemoteDriverConfig;
 import com.googlecode.jmeter.plugins.webdriver.config.WebDriverConfig;
 
@@ -57,7 +57,7 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui {
 		if (element instanceof RemoteDriverConfig) {
 			RemoteDriverConfig config = (RemoteDriverConfig) element;
 			config.setSeleniumGridUrl(remoteSeleniumGridText.getText());
-			config.setCapability((RemoteCapability) capabilitiesComboBox.getSelectedItem());
+			config.setSelectedBrowser((RemoteBrowser) browserCapabilitiesComboBox.getSelectedItem());
 			config.setLocalFileDetector(localFileDetector.isSelected());
 		}
 	}
@@ -66,7 +66,7 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui {
 	public void clearGui() {
 		super.clearGui();
 		remoteSeleniumGridText.setText(StringUtils.EMPTY);
-		capabilitiesComboBox.setSelectedIndex(1);
+		browserCapabilitiesComboBox.setSelectedIndex(1);
 		localFileDetector.setSelected(false);
 	}
 
@@ -76,7 +76,7 @@ public class RemoteDriverConfigGui extends WebDriverConfigGui {
 		if (element instanceof RemoteDriverConfig) {
 			RemoteDriverConfig config = (RemoteDriverConfig) element;
 			remoteSeleniumGridText.setText(config.getSeleniumGridUrl());
-			capabilitiesComboBox.setSelectedItem(config.getCapability());
+			browserCapabilitiesComboBox.setSelectedItem(config.getSelectedBrowser());
 			localFileDetector.setSelected(config.isLocalFileDectedor());
 		}
 	}

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/WebDriverSampler.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/sampler/WebDriverSampler.java
@@ -35,7 +35,9 @@ public class WebDriverSampler extends AbstractSampler {
     public static final String SCRIPT = "WebDriverSampler.script";
     public static final String PARAMETERS = "WebDriverSampler.parameters";
     private static final Logger LOGGER = LoggerFactory.getLogger(WebDriverSampler.class);
-    public static final String DEFAULT_ENGINE = "javascript";
+    // javascript engine removed in jdk>13 https://openjdk.org/jeps/372
+    // existing defaultScript works in groovy
+    public static final String DEFAULT_ENGINE = "groovy";
     public static final String SCRIPT_LANGUAGE = "WebDriverSampler.language";
     private final transient ScriptEngineManager scriptEngineManager;
     private final Class<SampleResult> sampleResultClass;

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -32,6 +32,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -159,6 +160,13 @@ public class ChromeDriverConfigTest {
     public void shouldHaveProxyInCapability() {
         final ChromeOptions options = config.createChromeOptions();
         assertThat(options.getCapability(CapabilityType.PROXY), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldMergeCustomCapabilities() {
+        config.setCustomCapabilities("{\"myCustomCapability\": \"myCustomValue\"}");
+        final Capabilities capabilities = config.createChromeOptions();
+        assertThat(capabilities.getCapability("myCustomCapability"), is("myCustomValue"));
     }
 
     @Test

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/EdgeDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/EdgeDriverConfigTest.java
@@ -32,6 +32,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.edge.EdgeDriverService;
 import org.openqa.selenium.edge.EdgeOptions;
@@ -159,6 +160,13 @@ public class EdgeDriverConfigTest {
     public void shouldHaveProxyInCapability() {
         final EdgeOptions options = config.createEdgeOptions();
         assertThat(options.getCapability(CapabilityType.PROXY), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldMergeCustomCapabilities() {
+        config.setCustomCapabilities("{\"myCustomCapability\": \"myCustomValue\"}");
+        final Capabilities capabilities = config.createEdgeOptions();
+        assertThat(capabilities.getCapability("myCustomCapability"), is("myCustomValue"));
     }
 
     @Test

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/FirefoxDriverConfigTest.java
@@ -24,6 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxDriverService;
 import org.openqa.selenium.firefox.FirefoxOptions;
@@ -95,5 +96,12 @@ public class FirefoxDriverConfigTest {
     public void shouldHaveProxyInCapability() {
         final FirefoxOptions options = config.createFirefoxOptions();
         assertThat(options.getCapability(CapabilityType.PROXY), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldMergeCustomCapabilities() {
+        config.setCustomCapabilities("{\"myCustomCapability\": \"myCustomValue\"}");
+        final Capabilities capabilities = config.createFirefoxOptions();
+        assertThat(capabilities.getCapability("myCustomCapability"), is("myCustomValue"));
     }
 }

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/HtmlUnitDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/HtmlUnitDriverConfigTest.java
@@ -81,4 +81,11 @@ public class HtmlUnitDriverConfigTest {
         final Capabilities capabilities = config.createCapabilities();
         assertThat(capabilities.getCapability(CapabilityType.PROXY), is(notNullValue()));
     }
+
+    @Test
+    public void shouldMergeCustomCapabilities() {
+        config.setCustomCapabilities("{\"myCustomCapability\": \"myCustomValue\"}");
+        final Capabilities capabilities = config.createCapabilities();
+        assertThat(capabilities.getCapability("myCustomCapability"), is("myCustomValue"));
+    }
 }

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/InternetExplorerDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/InternetExplorerDriverConfigTest.java
@@ -162,6 +162,13 @@ public class InternetExplorerDriverConfigTest {
     }
 
     @Test
+    public void shouldMergeCustomCapabilities() {
+        config.setCustomCapabilities("{\"myCustomCapability\": \"myCustomValue\"}");
+        final Capabilities capabilities = config.createIEOptions();
+        assertThat(capabilities.getCapability("myCustomCapability"), is("myCustomValue"));
+    }
+
+    @Test
     public void getSetCleanSession() {
         assertThat(config.isEnsureCleanSession(), is(false));
         config.setEnsureCleanSession(true);

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
@@ -49,7 +49,7 @@ public class RemoteDriverConfigTest {
     public void createConfig() {
         config = new RemoteDriverConfig();
         variables = new JMeterVariables();
-        config.setCapability(RemoteCapability.CHROME);
+        config.setSelectedBrowser(RemoteBrowser.CHROME);
         JMeterContextService.getContext().setVariables(variables);
     }
 
@@ -61,11 +61,11 @@ public class RemoteDriverConfigTest {
     
     @Test
 	public void shouldSetTheCapability() throws Exception {
-		assertThat(config.getCapability(), is(RemoteCapability.CHROME));
-		config.setCapability(RemoteCapability.FIREFOX);
-		assertThat(config.getCapability(), is(RemoteCapability.FIREFOX));
-		config.setCapability(RemoteCapability.INTERNET_EXPLORER);
-		assertThat(config.getCapability(), is(RemoteCapability.INTERNET_EXPLORER));
+		assertThat(config.getSelectedBrowser(), is(RemoteBrowser.CHROME));
+		config.setSelectedBrowser(RemoteBrowser.FIREFOX);
+		assertThat(config.getSelectedBrowser(), is(RemoteBrowser.FIREFOX));
+		config.setSelectedBrowser(RemoteBrowser.INTERNET_EXPLORER);
+		assertThat(config.getSelectedBrowser(), is(RemoteBrowser.INTERNET_EXPLORER));
 	}
 
     @Test
@@ -103,6 +103,13 @@ public class RemoteDriverConfigTest {
         final Capabilities capabilities = config.createCapabilities();
         assertThat(capabilities.getCapability(CapabilityType.PROXY), is(notNullValue()));
         assertThat(capabilities.getCapability(ChromeOptions.CAPABILITY), is(notNullValue()));
+    }
+
+    @Test
+    public void shouldMergeCustomCapabilities() {
+        config.setCustomCapabilities("{\"myCustomCapability\": \"myCustomValue\"}");
+        final Capabilities capabilities = config.createCapabilities();
+        assertThat(capabilities.getCapability("myCustomCapability"), is("myCustomValue"));
     }
 
     @Test

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGuiTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/gui/RemoteDriverConfigGuiTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.googlecode.jmeter.plugins.webdriver.config.RemoteCapability;
+import com.googlecode.jmeter.plugins.webdriver.config.RemoteBrowser;
 import com.googlecode.jmeter.plugins.webdriver.config.RemoteDriverConfig;
 import kg.apc.emulators.TestJMeterUtils;
 
@@ -73,11 +73,11 @@ public class RemoteDriverConfigGuiTest {
     public void shouldSetRemoteDriverConfigOnConfigure() {
         RemoteDriverConfig config = new RemoteDriverConfig();
         config.setSeleniumGridUrl("my.awesome.grid.com");
-        config.setCapability(RemoteCapability.FIREFOX);
+        config.setSelectedBrowser(RemoteBrowser.FIREFOX);
         gui.configure(config);
 
         assertThat(gui.remoteSeleniumGridText.getText(), is(config.getSeleniumGridUrl()));
-        assertThat((RemoteCapability)gui.capabilitiesComboBox.getSelectedItem(), is(config.getCapability()));
+        assertThat((RemoteBrowser)gui.browserCapabilitiesComboBox.getSelectedItem(), is(config.getSelectedBrowser()));
         assertFalse(gui.headless.isSelected());
     }
 
@@ -85,7 +85,7 @@ public class RemoteDriverConfigGuiTest {
     public void shouldSetHeadlessEnabledOnConfigure() {
         RemoteDriverConfig config = new RemoteDriverConfig();
         config.setSeleniumGridUrl("my.awesome.grid.com");
-        config.setCapability(RemoteCapability.CHROME);
+        config.setSelectedBrowser(RemoteBrowser.CHROME);
         config.setHeadless(true);
         gui.configure(config);
         assertTrue(gui.headless.isSelected());


### PR DESCRIPTION
New feature: Allows custom insertion of user-input capabilities / desiredCapabilities.
UI input is Json, parsed by Jackson.ObjectMapper - includes preview pane for pretty printing and any Json-parse related troubleshooting.

Use case1: W3C allows extension capabilities, used by vendors: https://www.w3.org/TR/webdriver1/#dfn-extension-capability
Use case2: Some webdriver requests require authentication via capabilities parameter.  This enables that.

Added new tab (added to all configurations) to handle input, parsing, & troubleshooting abilities.

Valid Json Example:
<img width="1494" alt="Screen Shot 2023-03-24 at 12 09 07 PM" src="https://user-images.githubusercontent.com/2797568/227593900-ef2e8e9a-f65a-417f-b756-e97f857c0ba2.png">

Invalid Json Example:
<img width="1494" alt="Screen Shot 2023-03-24 at 12 10 11 PM" src="https://user-images.githubusercontent.com/2797568/227594128-07c5f69a-d024-45f9-ba8b-d566f87d5161.png">
