### PR TITLE
Update Selenium support (4.13 -> 4.15)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-webdriver</artifactId>
-    <version>4.13.0.0</version>
+    <version>4.15.0.0</version>
     <packaging>jar</packaging>
 
     <name>WebDriver/Selenium</name>
@@ -34,7 +34,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <selenium.version>4.13.0</selenium.version>
+        <!--    "Chrome DevTools support is now: v117, v118, and v119 (Firefox still uses v85 for all versions)"    -->
+        <!--    @see https://www.selenium.dev/blog/2023/selenium-4-15-released/    -->
+        <selenium.version>4.15.0</selenium.version>
     </properties>
 
     <build>
@@ -51,22 +53,22 @@
                 </configuration>
             </plugin>
             <plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M7</version>
-				<configuration>
-					<argLine>
-						--add-opens java.base/java.io=ALL-UNNAMED
-						--add-opens java.base/java.lang=ALL-UNNAMED
-						--add-opens java.base/java.lang.reflect=ALL-UNNAMED
-						--add-opens java.base/java.time=ALL-UNNAMED
-						--add-opens java.base/java.util=ALL-UNNAMED
-						--add-opens java.base/java.util.concurrent=ALL-UNNAMED
-						--add-opens java.base/java.util.stream=ALL-UNNAMED
-						--add-opens=java.base/sun.security.jca=ALL-UNNAMED
-					</argLine>
-				</configuration>
-			</plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens java.base/java.time=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+                        --add-opens java.base/java.util.stream=ALL-UNNAMED
+                        --add-opens=java.base/sun.security.jca=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -141,9 +143,16 @@
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>htmlunit-driver</artifactId>
+            <artifactId>htmlunit3-driver</artifactId>
+            <version>4.15.0</version>
+        </dependency>
+        <!-- @since 4.15.0.0 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-manager</artifactId>
             <version>${selenium.version}</version>
         </dependency>
+
         <!-- begin need this libraries for HtmlUnitDriver -->
         <dependency>
             <groupId>xml-apis</groupId>
@@ -202,4 +211,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.3</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>de.sciss</groupId>

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/ChromeDriverConfigTest.java
@@ -179,15 +179,14 @@ public class ChromeDriverConfigTest {
 		@SuppressWarnings("unchecked")
 		List<String> args = (List<String>) capability.get("args");
         assertThat(args, is(notNullValue()));
-        assertEquals(2, args.size());
-        assertEquals("--remote-allow-origins=*", args.get(0));
-        assertEquals("--headless=new", args.get(1));
+        assertEquals(1, args.size());
+        assertEquals("--headless=new", args.get(0));
     }
 
     @Test
     public void shouldNotHaveChromeOptionsWhenRemoteIsNotEnabled() {
         final ChromeOptions options = config.createChromeOptions();
-        org.hamcrest.MatcherAssert.assertThat(options.getCapability(ChromeOptions.CAPABILITY), Matchers.hasToString("{args=[--remote-allow-origins=*], extensions=[]}"));
+        org.hamcrest.MatcherAssert.assertThat(options.getCapability(ChromeOptions.CAPABILITY), Matchers.hasToString("{args=[], extensions=[]}"));
     }
 
     @Test

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/EdgeDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/EdgeDriverConfigTest.java
@@ -179,15 +179,14 @@ public class EdgeDriverConfigTest {
 		@SuppressWarnings("unchecked")
 		List<String> args = (List<String>) capability.get("args");
         assertThat(args, is(notNullValue()));
-        assertEquals(2, args.size());
-        assertEquals("--remote-allow-origins=*", args.get(0));
-        assertEquals("--headless=new", args.get(1));
+        assertEquals(1, args.size());
+        assertEquals("--headless=new", args.get(0));
     }
 
     @Test
     public void shouldNotHaveEdgeOptionsWhenRemoteIsNotEnabled() {
         final EdgeOptions options = config.createEdgeOptions();
-        org.hamcrest.MatcherAssert.assertThat(options.getCapability(EdgeOptions.CAPABILITY), Matchers.hasToString("{args=[--remote-allow-origins=*], extensions=[]}"));
+        org.hamcrest.MatcherAssert.assertThat(options.getCapability(EdgeOptions.CAPABILITY), Matchers.hasToString("{args=[], extensions=[]}"));
     }
 
     @Test

--- a/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
+++ b/src/test/java/com/googlecode/jmeter/plugins/webdriver/config/RemoteDriverConfigTest.java
@@ -58,7 +58,7 @@ public class RemoteDriverConfigTest {
         config.clearThreadBrowsers();
         JMeterContextService.getContext().setVariables(null);
     }
-    
+
     @Test
 	public void shouldSetTheCapability() throws Exception {
 		assertThat(config.getSelectedBrowser(), is(RemoteBrowser.CHROME));
@@ -122,9 +122,8 @@ public class RemoteDriverConfigTest {
 		@SuppressWarnings("unchecked")
 		List<String> args = (List<String>) capability.get("args");
         assertThat(args, is(notNullValue()));
-        assertEquals(2, args.size());
-        assertEquals("--remote-allow-origins=*", args.get(0));
-        assertEquals("--headless=new", args.get(1));
+        assertEquals(1, args.size());
+        assertEquals("--headless=new", args.get(0));
     }
 
     @Test
@@ -137,7 +136,7 @@ public class RemoteDriverConfigTest {
 		@SuppressWarnings("unchecked")
 		List<String> args = (List<String>) capability.get("args");
         assertThat(args, is(notNullValue()));
-        assertEquals(1, args.size());
+        assertEquals(0, args.size());
     }
 
     @Test


### PR DESCRIPTION
@undera  I was struggling with our JMeter/Selenium setup this past week and after a lot of debugging found our issues. We want to run on Chrome 119 but jpgc-webdriver@4.13.0 doesnt support it.
So I decided to look into your project.
Would be great if this pull request could be merged since my team relies on the jpgc-webdriver.