### PR TITLE
make ftp and socks proxies optional

### DIFF
--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/WebDriverConfig.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/WebDriverConfig.java
@@ -92,8 +92,10 @@ public abstract class WebDriverConfig<T extends WebDriver> extends ConfigTestEle
 	private static final String USE_HTTP_FOR_ALL_PROTOCOLS = "WebDriverConfig.use_http_for_all_protocols";
 	private static final String HTTPS_HOST = "WebDriverConfig.https_host";
 	private static final String HTTPS_PORT = "WebDriverConfig.https_port";
+	private static final String USE_FTP_PROXY = "WebDriverConfig.use_ftp_proxy";
 	private static final String FTP_HOST = "WebDriverConfig.ftp_host";
 	private static final String FTP_PORT = "WebDriverConfig.ftp_port";
+	private static final String USE_SOCKS_PROXY = "WebDriverConfig.use_socks_proxy";
 	private static final String SOCKS_HOST = "WebDriverConfig.socks_host";
 	private static final String SOCKS_PORT = "WebDriverConfig.socks_port";
 	private static final String NO_PROXY = "WebDriverConfig.no_proxy";
@@ -255,8 +257,18 @@ public abstract class WebDriverConfig<T extends WebDriver> extends ConfigTestEle
 			}
 			ProxyHostPort http = new ProxyHostPort(getHttpHost(), getHttpPort());
 			ProxyHostPort https = new ProxyHostPort(getHttpsHost(), getHttpsPort());
-			ProxyHostPort ftp = new ProxyHostPort(getFtpHost(), getFtpPort());
-			ProxyHostPort socks = new ProxyHostPort(getSocksHost(), getSocksPort());
+
+			ProxyHostPort ftp = null;
+			if (isUseFtpProxy()) {
+				ftp = new ProxyHostPort(getFtpHost(), getFtpPort());
+			}
+
+			ProxyHostPort socks = null;
+
+			if (isUseSocksProxy()) {
+				socks = new ProxyHostPort(getSocksHost(), getSocksPort());
+			}
+
 			return proxyFactory.getManualProxy(http, https, ftp, socks, getNoProxyHost());
 		default:
 			return proxyFactory.getSystemProxy();
@@ -585,6 +597,22 @@ public abstract class WebDriverConfig<T extends WebDriver> extends ConfigTestEle
 	}
 	public void setUseHttpSettingsForAllProtocols(boolean override) {
 		setProperty(USE_HTTP_FOR_ALL_PROTOCOLS, override);
+	}
+
+	public boolean isUseFtpProxy() {
+		return getPropertyAsBoolean(USE_FTP_PROXY, true);
+	}
+
+	public void setUseFtpProxy(boolean useFtpProxy) {
+		setProperty(USE_FTP_PROXY, useFtpProxy);
+	}
+
+	public boolean isUseSocksProxy() {
+		return getPropertyAsBoolean(USE_SOCKS_PROXY, true);
+	}
+
+	public void setUseSocksProxy(boolean useSocksProxy) {
+		setProperty(USE_SOCKS_PROXY, useSocksProxy);
 	}
 
     public boolean isHeadless() {

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/WebDriverConfigGui.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/config/gui/WebDriverConfigGui.java
@@ -102,6 +102,9 @@ public abstract class WebDriverConfigGui extends AbstractConfigGui implements Fo
 	JFormattedTextField socksProxyPort;
 	JRadioButton systemProxy;
 	JCheckBox useHttpSettingsForAllProtocols;
+	JCheckBox useFtpProxy;
+	JCheckBox useSocksProxy;
+
 	JTextArea customCapabilitiesTextArea;
 
 	public static final String WIKIPAGE = "https://github.com/undera/jmeter-plugins-webdriver";
@@ -390,10 +393,23 @@ public abstract class WebDriverConfigGui extends AbstractConfigGui implements Fo
 		httpsProxyPort.setText(String.valueOf(DEFAULT_PROXY_PORT));
 		manualPanel.add(createProxyHostAndPortPanel(httpsProxyHost, httpsProxyPort, "SSL Proxy:"));
 
+		useFtpProxy = new JCheckBox("Set the FTP proxy");
+		useFtpProxy.setSelected(true);
+		useFtpProxy.setEnabled(false);
+		useFtpProxy.addItemListener(this);
+		manualPanel.add(useFtpProxy);
+
 		ftpProxyHost = new JTextField();
 		ftpProxyPort = new JFormattedTextField(NUMBER_FORMAT);
 		ftpProxyPort.setText(String.valueOf(DEFAULT_PROXY_PORT));
 		manualPanel.add(createProxyHostAndPortPanel(ftpProxyHost, ftpProxyPort, "FTP Proxy:"));
+
+
+		useSocksProxy = new JCheckBox("Set the SOCKS proxy");
+		useSocksProxy.setSelected(true);
+		useSocksProxy.setEnabled(false);
+		useSocksProxy.addItemListener(this);
+		manualPanel.add(useSocksProxy);
 
 		socksProxyHost = new JTextField();
 		socksProxyPort = new JFormattedTextField(NUMBER_FORMAT);
@@ -550,6 +566,8 @@ public abstract class WebDriverConfigGui extends AbstractConfigGui implements Fo
 			enableOtherProtocolsOnlyIfManualProxySelectedAndUseHttpSettingsIsNotSelected();
 		} else if (itemEvent.getSource() == useHttpSettingsForAllProtocols) {
 			enableOtherProtocolsOnlyIfManualProxySelectedAndUseHttpSettingsIsNotSelected();
+		} else if (itemEvent.getSource() == useFtpProxy || itemEvent.getSource() == useSocksProxy) {
+			enableOtherProtocolsOnlyIfManualProxySelectedAndUseHttpSettingsIsNotSelected();
 		} else if (itemEvent.getSource() == userAgentOverrideCheckbox) {
 			userAgentOverrideText.setEnabled(userAgentOverrideCheckbox.isSelected());
 		}
@@ -559,10 +577,12 @@ public abstract class WebDriverConfigGui extends AbstractConfigGui implements Fo
 		final boolean enabledState = !useHttpSettingsForAllProtocols.isSelected() && manualProxy.isSelected();
 		httpsProxyHost.setEnabled(enabledState);
 		httpsProxyPort.setEnabled(enabledState);
-		ftpProxyHost.setEnabled(enabledState);
-		ftpProxyPort.setEnabled(enabledState);
-		socksProxyHost.setEnabled(enabledState);
-		socksProxyPort.setEnabled(enabledState);
+		useFtpProxy.setEnabled(!useHttpSettingsForAllProtocols.isSelected());
+		ftpProxyHost.setEnabled(enabledState && useFtpProxy.isSelected());
+		ftpProxyPort.setEnabled(enabledState && useFtpProxy.isSelected());
+		useSocksProxy.setEnabled(!useHttpSettingsForAllProtocols.isSelected());
+		socksProxyHost.setEnabled(enabledState && useSocksProxy.isSelected());
+		socksProxyPort.setEnabled(enabledState && useSocksProxy.isSelected());
 	}
 
 	@Override
@@ -625,8 +645,10 @@ public abstract class WebDriverConfigGui extends AbstractConfigGui implements Fo
 		useHttpSettingsForAllProtocols.setSelected(true);
 		httpsProxyHost.setText("");
 		httpsProxyPort.setText(String.valueOf(DEFAULT_PROXY_PORT));
+		useFtpProxy.setSelected(true);
 		ftpProxyHost.setText("");
 		ftpProxyPort.setText(String.valueOf(DEFAULT_PROXY_PORT));
+		useSocksProxy.setSelected(true);
 		socksProxyHost.setText("");
 		socksProxyPort.setText(String.valueOf(DEFAULT_PROXY_PORT));
 		noProxyList.setText(DEFAULT_NO_PROXY_LIST);
@@ -668,7 +690,7 @@ public abstract class WebDriverConfigGui extends AbstractConfigGui implements Fo
 			}
 
 			// Firefox configs
-			if ((browserName().equals("firefox")) || (browserName().equals("Remote"))) {				
+			if ((browserName().equals("firefox")) || (browserName().equals("Remote"))) {
 				userAgentOverrideCheckbox.setSelected(webDriverConfig.isUserAgentOverridden());
 				userAgentOverrideText.setText(webDriverConfig.getUserAgentOverride());
 				userAgentOverrideText.setEnabled(webDriverConfig.isUserAgentOverridden());
@@ -720,8 +742,10 @@ public abstract class WebDriverConfigGui extends AbstractConfigGui implements Fo
 		useHttpSettingsForAllProtocols.setSelected(webDriverConfig.isUseHttpSettingsForAllProtocols());
 		httpsProxyHost.setText(webDriverConfig.getHttpsHost());
 		httpsProxyPort.setText(String.valueOf(webDriverConfig.getHttpsPort()));
+		useFtpProxy.setSelected(webDriverConfig.isUseFtpProxy());
 		ftpProxyHost.setText(webDriverConfig.getFtpHost());
 		ftpProxyPort.setText(String.valueOf(webDriverConfig.getFtpPort()));
+		useSocksProxy.setSelected(webDriverConfig.isUseSocksProxy());
 		socksProxyHost.setText(webDriverConfig.getSocksHost());
 		socksProxyPort.setText(String.valueOf(webDriverConfig.getSocksPort()));
 		noProxyList.setText(webDriverConfig.getNoProxyHost());
@@ -806,8 +830,10 @@ public abstract class WebDriverConfigGui extends AbstractConfigGui implements Fo
 		webDriverConfig.setUseHttpSettingsForAllProtocols(useHttpSettingsForAllProtocols.isSelected());
 		webDriverConfig.setHttpsHost(httpsProxyHost.getText());
 		webDriverConfig.setHttpsPort(Integer.parseInt(httpsProxyPort.getText()));
+		webDriverConfig.setUseFtpProxy(useFtpProxy.isSelected());
 		webDriverConfig.setFtpHost(ftpProxyHost.getText());
 		webDriverConfig.setFtpPort(Integer.parseInt(ftpProxyPort.getText()));
+		webDriverConfig.setUseSocksProxy(useSocksProxy.isSelected());
 		webDriverConfig.setSocksHost(socksProxyHost.getText());
 		webDriverConfig.setSocksPort(Integer.parseInt(socksProxyPort.getText()));
 		webDriverConfig.setNoProxyHost(noProxyList.getText());

--- a/src/main/java/com/googlecode/jmeter/plugins/webdriver/proxy/ProxyFactory.java
+++ b/src/main/java/com/googlecode/jmeter/plugins/webdriver/proxy/ProxyFactory.java
@@ -12,28 +12,39 @@ public class ProxyFactory {
         return INSTANCE;
     }
 
-    private ProxyFactory() {}
+    private ProxyFactory() {
+    }
 
     /**
-     * This returns a {@link Proxy} with HTTP, HTTPS and FTP hosts and ports configured as specified.
+     * This returns a {@link Proxy} with HTTP, HTTPS and FTP hosts and ports
+     * configured as specified.
      *
      *
-     * @param httpProxy is the http proxy host and port
+     * @param httpProxy  is the http proxy host and port
      * @param httpsProxy is the https proxy host and port
-     * @param ftpProxy is the ftp proxy host and port
+     * @param ftpProxy   is the ftp proxy host and port
      * @param socksProxy is the socks proxy host and port
-     * @param noProxy is a comma separated list of hosts that will bypass the proxy
+     * @param noProxy    is a comma separated list of hosts that will bypass the
+     *                   proxy
      *
      * @return a proxy object with the hosts manually specified.
      */
-    public Proxy getManualProxy(ProxyHostPort httpProxy, ProxyHostPort httpsProxy, ProxyHostPort ftpProxy, ProxyHostPort socksProxy, String noProxy) {
-        return new Proxy()
-            .setProxyType(Proxy.ProxyType.MANUAL)
-            .setHttpProxy(httpProxy.toUnifiedForm())
-            .setSslProxy(httpsProxy.toUnifiedForm())
-            .setFtpProxy(ftpProxy.toUnifiedForm())
-            .setSocksProxy(socksProxy.toUnifiedForm())
-            .setNoProxy(noProxy);
+    public Proxy getManualProxy(ProxyHostPort httpProxy, ProxyHostPort httpsProxy, ProxyHostPort ftpProxy,
+            ProxyHostPort socksProxy, String noProxy) {
+        Proxy proxy = new Proxy().setProxyType(Proxy.ProxyType.MANUAL).setNoProxy(noProxy);
+        if (httpProxy != null) {
+            proxy.setHttpProxy(httpProxy.toUnifiedForm());
+        }
+        if (httpsProxy != null) {
+            proxy.setSslProxy(httpsProxy.toUnifiedForm());
+        }
+        if (ftpProxy != null) {
+            proxy.setFtpProxy(ftpProxy.toUnifiedForm());
+        }
+        if (socksProxy != null) {
+            proxy.setSocksProxy(socksProxy.toUnifiedForm());
+        }
+        return proxy;
     }
 
     /**
@@ -43,31 +54,34 @@ public class ProxyFactory {
      */
     public Proxy getDirectProxy() {
         return new Proxy()
-            .setProxyType(Proxy.ProxyType.DIRECT);
+                .setProxyType(Proxy.ProxyType.DIRECT);
     }
 
     /**
      * This is a proxy which will have its settings automatically configured.
      *
-     * @return a proxy object which will try to automatically detect the proxy settings.
+     * @return a proxy object which will try to automatically detect the proxy
+     *         settings.
      */
     public Proxy getAutodetectProxy() {
         return new Proxy()
-            .setProxyType(Proxy.ProxyType.AUTODETECT)
-            .setAutodetect(true);
+                .setProxyType(Proxy.ProxyType.AUTODETECT)
+                .setAutodetect(true);
     }
 
     /**
-     * If the proxy can be configured using a PAC file at a URL, set this value to the location of this PAC file.
+     * If the proxy can be configured using a PAC file at a URL, set this value to
+     * the location of this PAC file.
      *
      * @param pacUrl is the url to the Proxy PAC file
      *
-     * @return a proxy object with its proxies configured automatically using a PAC file.
+     * @return a proxy object with its proxies configured automatically using a PAC
+     *         file.
      */
     public Proxy getConfigUrlProxy(String pacUrl) {
         return new Proxy()
-            .setProxyType(Proxy.ProxyType.PAC)
-            .setProxyAutoconfigUrl(pacUrl);
+                .setProxyType(Proxy.ProxyType.PAC)
+                .setProxyAutoconfigUrl(pacUrl);
     }
 
     /**
@@ -77,6 +91,6 @@ public class ProxyFactory {
      */
     public Proxy getSystemProxy() {
         return new Proxy()
-            .setProxyType(Proxy.ProxyType.SYSTEM);
+                .setProxyType(Proxy.ProxyType.SYSTEM);
     }
 }


### PR DESCRIPTION
(Opening pull requests from master branch to trigger Github actions)

Ran into this issue with 4.13.0.0 when trying to use the firefox driver config:

```log
org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: Since Firefox 90 'ftpProxy' is no longer supported
```

And ran into this on Chrome, Edge, and Firefox driver config where the plugin was not setting the socksVersion in the org.openqa.selenium.Proxy object (default value is null) :
```log
org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 400. Message: invalid argument: entry 0 of 'firstMatch' is invalid
from invalid argument: cannot parse capability: proxy
from invalid argument: 'socksVersion' must be between 0 and 255 
```

So I dug into the source code and found that there's no way to selectively unset the different protocol proxies to sidestep these issues.

This PR aims to address this issue by allowing the user to unset FTP and SOCKS proxies individually by adding the appropriate check boxes for the user to toggle.
